### PR TITLE
Fix trailing line for package.el compatibility

### DIFF
--- a/scratch-pop.el
+++ b/scratch-pop.el
@@ -88,4 +88,4 @@
 
 (provide 'scratch-pop)
 
-;; scratch-pop.el ends here
+;;; scratch-pop.el ends here


### PR DESCRIPTION
Three semicolons are required for `package-buffer-info` to correctly parse the file.

P.S. I'm adding a [MELPA](http://melpa.milkbox.net) recipe for this library.
